### PR TITLE
kmal/issue forms - adding new issue forms to templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+## Request for changes / Pull Requests
+To start create a fork of the [Hawaii-Zoning-Atlas](https://github.com/CodeforHawaii/Hawaii-Zoning-Atlas) repo to commit your changes to. Methods to fork a repository can be found in the [GitHub Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
+Then add your fork as a local project:
+
+```sh
+# Using HTTPS
+git clone https://github.com/CodeforHawaii/Hawaii-Zoning-Atlas
+
+# Using SSH
+git clone git@github.com:CodeforHawaii/Hawaii-Zoning-Atlas.git
+```
+
+> [Which remote URL should be used ?](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories)
+
+Then, go to your local folder
+
+```sh
+cd Hawaii-Zoning-Atlas
+```
+
+Add git remote controls :
+
+```sh
+# Using HTTPS
+git remote add fork https://github.com/YOUR-USERNAME/Hawaii-Zoning-Atlas.git
+git remote add upstream https://github.com/CodeforHawaii/Hawaii-Zoning-Atlas.git
+
+
+# Using SSH
+git remote add fork git@github.com:YOUR-USERNAME/Hawaii-Zoning-Atlas.git
+git remote add upstream git@github.com/CodeforHawaii/Hawaii-Zoning-Atlas.git
+```
+
+You can now verify that you have your two git remotes:
+
+```sh
+git remote -v
+```
+
+## Receive remote updates
+In view of staying up to date with the central repository :
+
+```sh
+git pull upstream main
+```
+
+## Choose a base branch
+Before starting development, you need to know which branch to base your modifications/additions on. When in doubt, use main
+
+| Type of change                |           | Branches              |
+| :------------------           |:---------:| ---------------------:|
+| Documentation                 |           | `main`                |
+| Bug fixes                     |           | `main`                |
+| New features                  |           | `main`                |
+| New issues models             |           | `YOUR-USERNAME/patch` |
+
+```sh
+# Switch to the desired branch
+git switch main
+
+# Pull down any upstream changes
+git pull
+
+# Create a new branch to work on
+git switch --create patch/1234-name-issue
+```
+
+Commit your changes, then push the branch to your fork with `git push -u fork` and open a pull request on [the Hawaii-Zoning-Atlas](https://github.com/CodeforHawaii/Hawaii-Zoning-Atlas/) following the template provided.

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,25 +1,30 @@
 name: "🐛 Bug Report"
-description: Create a new ticket for a bug.
+description: File a bug report
 title: "🐛 [BUG] - <title>"
 labels: [
   "bug",
   "triage"
 ]
 body:
-  - type: textarea
-    id: description
+   - type: markdown
     attributes:
-      label: "Description"
-      description: Please enter a detailed description of your issue
-      placeholder: Short description of your incident...
+      value: |
+        Thanks for taking the time to fill out this bug report!
+   - type: input
+     id: contact
+     attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
     validations:
-      required: true
-  - type: input
-    id: reprod-url
+      required: false
+  - type: textarea
+    id: what-happened
     attributes:
-      label: "Reproduction URL"
-      description: Please enter your GitHub URL to provide a reproduction of the issue
-      placeholder: ex. https://github.com/USERNAME/REPO-NAME
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
     validations:
       required: true
   - type: textarea
@@ -71,7 +76,7 @@ body:
     id: os
     attributes:
       label: "OS"
-      description: What is the impacted environment ?
+      description: OS being used ?
       multiple: true
       options:
         - Windows
@@ -79,3 +84,11 @@ body:
         - Mac
     validations:
       required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/codeforhawaii/hawaii-zoning-atlas/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,81 @@
+name: "🐛 Bug Report"
+description: Create a new ticket for a bug.
+title: "🐛 [BUG] - <title>"
+labels: [
+  "bug",
+  "triage"
+]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Please enter a detailed description of your issue
+      placeholder: Short description of your incident...
+    validations:
+      required: true
+  - type: input
+    id: reprod-url
+    attributes:
+      label: "Reproduction URL"
+      description: Please enter your GitHub URL to provide a reproduction of the issue
+      placeholder: ex. https://github.com/USERNAME/REPO-NAME
+    validations:
+      required: true
+  - type: textarea
+    id: reprod
+    attributes:
+      label: "Reproduction steps"
+      description: Please enter detailed steps to reproduce
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: "Screenshots"
+      description: If applicable, add screenshots 
+      value: |
+        ![DESCRIPTION](LINK.png)
+      render: bash
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs"
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: bash
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: "Browsers"
+      description: What browsers are you seeing the problem on ?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Opera
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: "OS"
+      description: What is the impacted environment ?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - Mac
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -6,13 +6,13 @@ labels: [
   "triage"
 ]
 body:
-   - type: markdown
+  - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-   - type: input
-     id: contact
-     attributes:
+  - type: input
+    id: contact
+    attributes:
       label: Contact Details
       description: How can we get in touch with you if we need more info?
       placeholder: ex. email@example.com

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,63 @@
+name: "💡 Feature Request"
+description: Create an issue for a new feature request
+title: "💡 [REQUEST] - <title>"
+labels: [
+  "question"
+]
+body:
+  - type: input
+    id: start_date
+    attributes:
+      label: "Start Date"
+      description: Start of development
+      placeholder: "month/day/year"
+    validations:
+      required: false
+  - type: textarea
+    id: implementation_pr
+    attributes:
+      label: "Implementation PR"
+      description: Pull request used
+      placeholder: "#Pull Request ID"
+    validations:
+      required: false
+  - type: textarea
+    id: reference_issues
+    attributes:
+      label: "Reference Issues"
+      description: Common issues
+      placeholder: "#Issues IDs"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: Provide a brief explanation of the feature
+      placeholder: Describe in a few lines your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: basic_example
+    attributes:
+      label: "Basic Example"
+      description: Indicate here some basic examples of your feature.
+      placeholder: A few specific words about your feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: drawbacks
+    attributes:
+      label: "Drawbacks"
+      description: What are the drawbacks/impacts of your feature request ?
+      placeholder: Identify the drawbacks and impacts while being neutral on your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: unresolved_question
+    attributes:
+      label: "Unresolved questions"
+      description: What questions still remain unresolved ?
+      placeholder: Identify any unresolved issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Code for Hawaii
-    url: https://github.com/CodeforHawai/discussions
+    url: https://github.com/CodeforHawaii/discussions
     about: Start a conversation here
   - name: Code for Hawaii website
     url: https://codeforhawaii.org

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Code for Hawaii
+    url: https://github.com/CodeforHawai/discussions
+    about: Start a conversation here
+  - name: Code for Hawaii website
+    url: https://codeforhawaii.org
+    about: Contact us through our website form

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Code for Hawaii
+  - name: Community
     url: https://github.com/CodeforHawaii/discussions
     about: Start a conversation here
-  - name: Code for Hawaii website
-    url: https://codeforhawaii.org
-    about: Contact us through our website form
+  - name: Contact
+    url: mailto:info@codeforhawaii.org
+    about: Contact us here


### PR DESCRIPTION
Utilizing GitHubs new [Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) 

PR adds the following:

👀 `BUG-REPORT.yml`:

https://user-images.githubusercontent.com/20919083/215253949-364be3dc-b004-4293-a9ce-71845628e90b.mov

🪄 `FEATURE-REQUEST.yml`


https://user-images.githubusercontent.com/20919083/215254013-d0afdca0-441e-43f8-a635-5390c33bfae1.mov

These along with others coming soon will be used as issue templates for the repo. Along with the issue forms, additional files being added are `config.yml` and `CONTRIBUTING.md`.

