### PR TITLE
fix: hash and search params

### DIFF
--- a/scripts/leaflet-hash.js
+++ b/scripts/leaflet-hash.js
@@ -18,7 +18,7 @@
             hash = hash.substr(1);
         }
         var args = hash.split("/");
-        if (args.length == 3) {
+        if (args.length >= 3) {
             var zoom = parseInt(args[0], 10),
                 lat = parseFloat(args[1]),
                 lon = parseFloat(args[2]);
@@ -40,9 +40,13 @@
             zoom = map.getZoom(),
             precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
 
+        var currentHash = location.hash.split('/');
+        var filtersHash = currentHash.length >= 4 ? currentHash.slice(3).join('/') : null;
+
         return "#" + [zoom,
             center.lat.toFixed(precision),
-            center.lng.toFixed(precision)
+            center.lng.toFixed(precision),
+            filtersHash
         ].join("/");
     },
 


### PR DESCRIPTION
We had previously made some edits to the `leaflet-hash.js` script that broke the saved map filter state when the map was moved. Reverting this file to the original fixes this issue.