### PR TITLE
fix: uncheck senate state dhhl by default

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -98,10 +98,6 @@ var loadZones = function (geojson) {
     },
   }).addTo(map)
 
-  // Turn off federal/state land by default
-  $('input[name="Overlay"][value="federal"]').prop('checked', false)
-  $('input[name="Overlay"][value="state"]').prop('checked', false)
-  $('input[name="Overlay"][value="DHHL"]').prop('checked', false)
 
   // Add selected overlays to the map
   $('input[name="Overlay"]:checked').each(function (i, el) {

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -98,10 +98,10 @@ var loadZones = function (geojson) {
     },
   }).addTo(map)
 
-  // Turn on federal/state land by default
-  $('input[name="Overlay"][value="federal"]').prop('checked', true)
-  $('input[name="Overlay"][value="state"]').prop('checked', true)
-  $('input[name="Overlay"][value="DHHL"]').prop('checked', true)
+  // Turn off federal/state land by default
+  $('input[name="Overlay"][value="federal"]').prop('checked', false)
+  $('input[name="Overlay"][value="state"]').prop('checked', false)
+  $('input[name="Overlay"][value="DHHL"]').prop('checked', false)
 
   // Add selected overlays to the map
   $('input[name="Overlay"]:checked').each(function (i, el) {


### PR DESCRIPTION
senate, state, and DHHL are unchecked by default and will not be active when first loading the webpage. 