### PR TITLE
Reducing DHHL filesize

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -98,7 +98,6 @@ var loadZones = function (geojson) {
     },
   }).addTo(map)
 
-
   // Add selected overlays to the map
   $('input[name="Overlay"]:checked').each(function (i, el) {
     if (overlays[el.value]) {
@@ -572,7 +571,7 @@ var loadKauai = function () {
 }
 
 var loadDHHL = function () {
-  $.getJSON('./data/dhhl-land.geojson', function (geojson) {
+  $.getJSON('./data/dhhl-land-min.geojson', function (geojson) {
     var stripes = new L.StripePattern({
       height: 2,
       width: 2,


### PR DESCRIPTION
DHHL data file size reduced from 13.9 MB to 4.4 MB by simplifying the lines and reducing decimal precision to 0.00001.