### PR TITLE
Move opacity slider and footer text back to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
 		</div>
 
 		<h1 class="f3 mv2 black-90 dn">Hawaii Zoning Atlas</h1>
-		
 
 		<p class="f5 mv2">
 			This interactive map explores how restrictive zoning laws can make it
@@ -72,7 +71,6 @@
 			Use checkboxes below to filter zones in the map. Click a county to see
 			what % of its territory satisfies selected criteria.
 		</p>
-	</div>
 
 		<form id="form" class="f6 lh-title">
 			<input type="hidden" name="townActive" value="" />
@@ -527,7 +525,7 @@
 				Action</a>, and the
 			<a href="https://www.mercatus.org" class="link dim black-50 underline" target="_blank">Mercatus Center</a>.
 		</p>
+		</div>
 	</div>
 </body>
-
 </html>


### PR DESCRIPTION
# Sidebar fix 🧰 

Opacity slider and the footer text should be and used to be in the sidebar. This fix moves them back their orig location. See images for reference 👀 

# Broken 🤕 
<img width="1368" alt="broken-zone-opacity-location" src="https://user-images.githubusercontent.com/20919083/227591609-c19029ea-0bdf-4221-b58b-d0b68f1c02b6.png">

# Fixed 🩹 😄 
<img width="1269" alt="fix-zone-opacity-location" src="https://user-images.githubusercontent.com/20919083/227591633-33a5a96e-1d1c-4d71-8c9a-1801077928df.png">
