### PR TITLE
fix: pin driver.js to 0.9.8

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,9 @@
 	<script src="scripts/jquery.unserialize.js"></script>
 
 	<!-- Driver.js for first-time tour -->
-	<script src="https://unpkg.com/driver.js/dist/driver.min.js"></script>
-	<link rel="stylesheet" href="https://unpkg.com/driver.js/dist/driver.min.css" />
+	<!-- Source: https://github.com/kamranahmedse/driver.js -->
+	<script src="https://unpkg.com/driver.js@0.9.8/dist/driver.min.js"></script>
+	<link rel="stylesheet" href="https://unpkg.com/driver.js@0.9.8/dist/driver.min.css"/>
 
 	<!-- Load Esri Leaflet from CDN -->
 	<script src="https://unpkg.com/esri-leaflet@2.5.2/dist/esri-leaflet.js"></script>


### PR DESCRIPTION
Pinning [`driver.js`](https://github.com/kamranahmedse/driver.js) to v0.9.8, fixing the initial `driver.js` walkthrough

Basically our underlying dependency (https://github.com/kamranahmedse/driver.js) published a new major release (>1.X.X) that changes the way we need to use their library and the code we had in the website did not have a version pin, so we auto-upgraded without even knowing it. This PR includes a version pin to the previous version of `driver.js` so it shouldn't break anymore

<img width="909" alt="Screenshot 2023-08-15 at 3 54 23 AM" src="https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/assets/15609358/2e633c0d-7097-4f97-a2a6-3830243d92dc">
