### PR TITLE
Fixing the default color for not zoned areas

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -10,6 +10,7 @@ var zone2color = {
   M: '#714674eb', // mixed with residential, satisfied
   N: '#714674ab', // nonresidential, satisfied
   NS: '#d0d0d0', // not satisfied
+  NZ: "#DCDCDB"
 }
 
 // Columns in the original spreadsheet
@@ -28,7 +29,7 @@ var style = function (filters, feature) {
   // This fixes the null areas being blue by default
   if(feature.properties[zType] === null)
   {
-    fillColor = "#DCDCDB"
+    fillColor = zone2color['NZ'];
   }
   return {
     fillOpacity: opacity,

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -61,7 +61,6 @@ var loadZones = function (geojson) {
 
       // On layer click, select town
       layer.on('click', function () {
-        console.log("PP:", pp)
         var townClicked = pp[zTown]
         townActive = townClicked === townActive ? '' : townClicked
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -20,13 +20,20 @@ var zAcres = 'MA' // municipal area
 
 var style = function (filters, feature) {
   var opacity = $('input[name="opacity"]').val() / 100
+  let fillColor = satisfiesFilters(filters, feature)
+  ? zone2color[feature.properties[zType]]
+  : zone2color['NS'];
 
+  // If the feature is "Not Zoned" the properties[zType] will be null
+  // This fixes the null areas being blue by default
+  if(feature.properties[zType] === null)
+  {
+    fillColor = "#DCDCDB"
+  }
   return {
     fillOpacity: opacity,
-    fillColor: satisfiesFilters(filters, feature)
-      ? zone2color[feature.properties[zType]]
-      : zone2color['NS'],
-    weight: 0,
+    fillColor: fillColor,
+    weight: 0
   }
 }
 
@@ -54,6 +61,7 @@ var loadZones = function (geojson) {
 
       // On layer click, select town
       layer.on('click', function () {
+        console.log("PP:", pp)
         var townClicked = pp[zTown]
         townActive = townClicked === townActive ? '' : townClicked
 


### PR DESCRIPTION
The "Not Zoned" areas are blue by default. Blue is reserved for waterways according to:  https://edrnet.com/wp-content/uploads/2014/08/US-Topo-Map-Symbols.pdf

I updated the color to be a light grey instead.

This closes #96 

![image](https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/assets/17712276/cc61726c-aafb-4f17-bb82-a8416adaef56)
