### PR TITLE
fix: opacity slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,8 +506,6 @@
           value="senate" />
           Senate Districts
         </label>		
-      </div>
-		</div>
 
 			<div id="ZoneOpacity">
 				<h2 class="f5 mb1 black-40">Zone Opacity</h2>

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -20,7 +20,8 @@ var zType = 'Ty'
 var zAcres = 'MA' // municipal area
 
 var style = function (filters, feature) {
-  var opacity = $('input[name="opacity"]').val() / 100
+  var opacity = $('input[name="opacity"]').val() / 100;
+
   let fillColor = satisfiesFilters(filters, feature)
   ? zone2color[feature.properties[zType]]
   : zone2color['NS'];


### PR DESCRIPTION
Fixes the opacity slider by making sure the `opacity` element exists within the `form`.