### PR TITLE
tooltip alignment fix

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -334,7 +334,7 @@ var calculateActiveArea = function () {
       townActive +
       '</strong> (' +
       totalAcres +
-      ' acres) satisfies your filtering criteria.</p><div style="font-size: 13px"><span class="black-50 dib w-third fl tl" title="Median Household Income">' +
+      ' acres) satisfies your filtering criteria.</p><div style="font-size: 13px; display: flex"><span class="black-50 dib w-third fl tl" title="Median Household Income">' +
       '<span class="material-icons v-top" style="font-size:16px">payments</span> $' +
       demographics[townActive].income.toLocaleString() +
       '<br>HH Income</span><span class="black-50 dib w-third fl tc" title="Black, Indigenous, People of Color">' +


### PR DESCRIPTION
**Description**
New font typeface from [this PR](https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/pull/113) caused some of the tooltip details to be misaligned.

**Resolution**
Ideally, we want the three tooltip details to be grouped and have it's own css class and specifications in the style.css file, but for now, I just added a `display: flex` to the outer container.

**Before**
![Screenshot 2024-02-07 at 2 33 01 PM](https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/assets/7283964/ba9e4fad-e6fe-4706-b340-0ea8b3854808)

**After**
![Screenshot 2024-02-07 at 2 51 54 PM](https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/assets/7283964/31271f95-6f85-491c-9229-c8fb012d27a1)
