### PR TITLE
Correctly handle new lines in CSV validation script

### DIFF
--- a/data-pipeline/csv-validation/validation.py
+++ b/data-pipeline/csv-validation/validation.py
@@ -124,7 +124,7 @@ constraints = [
     ),
 ]
 
-table_full = etl.fromcsv("../hawaii-zoning-data.csv")
+table_full = etl.fromcsv("../hawaii-zoning-data.csv", newline='')
 table = etl.tail(table_full, table_full.len() - 2)
 problems = etl.validate(table, constraints=constraints, header=headers)
 if problems.len() > 2:

--- a/data-pipeline/csv-validation/validation.py
+++ b/data-pipeline/csv-validation/validation.py
@@ -1,3 +1,4 @@
+import csv
 import petl as etl
 from validators import validate_abbr_district_name, validate_county
 from validators import validate_jurisdiction, validate_state
@@ -124,10 +125,15 @@ constraints = [
     ),
 ]
 
-table_full = etl.fromcsv("../hawaii-zoning-data.csv", newline='')
-table = etl.tail(table_full, table_full.len() - 2)
-problems = etl.validate(table, constraints=constraints, header=headers)
-if problems.len() > 2:
-    print(problems.lookall())
-    raise Exception("Invalid Data")
-print("Success! No data errors found.")
+with open("../hawaii-zoning-data.csv", newline='') as csvfile:
+    csvfile_reader = csv.reader(csvfile)
+    table_full = []
+    for row in csvfile_reader:
+        table_full.append(row)
+
+    table = etl.tail(table_full, table_full.len() - 2)
+    problems = etl.validate(table, constraints=constraints, header=headers)
+    if problems.len() > 2:
+        print(problems.lookall())
+        raise Exception("Invalid Data")
+    print("Success! No data errors found.")

--- a/data-pipeline/csv-validation/validation.py
+++ b/data-pipeline/csv-validation/validation.py
@@ -127,11 +127,12 @@ constraints = [
 
 with open("../hawaii-zoning-data.csv", newline='') as csvfile:
     csvfile_reader = csv.reader(csvfile)
-    table_full = []
+    table_raw = []
     for row in csvfile_reader:
-        table_full.append(row)
+        table_raw.append(row)
 
-    table = etl.tail(table_full, table_full.len() - 2)
+    table_parsed = etl.fromcolumns(table_raw)
+    table = etl.tail(table_parsed, table_parsed.len() - 2)
     problems = etl.validate(table, constraints=constraints, header=headers)
     if problems.len() > 2:
         print(problems.lookall())


### PR DESCRIPTION
Correctly handle new lines in CSV validation script

Attempting to fix Github Action errors found where the CSV file new lines are not interpreted correctly.

> If newline='' is not specified, newlines embedded inside quoted fields will not be interpreted correctly, and on platforms that use \r\n linendings on write an extra \r will be added. It should always be safe to specify newline='', since the csv module does its own ([universal](https://docs.python.org/3/glossary.html#term-universal-newlines)) newline handling.
> https://docs.python.org/3/library/csv.html#csv.reader

We see that in the Google spreadsheet, there are some values that have new lines values in them.

Example failed run: https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/actions/runs/8231035064