### PR TITLE
Issue #116-Adding new paragraph with GH link at the bottom of the sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,6 +526,10 @@
 			Faith Action, and the
 			<a href="https://www.mercatus.org" class="link dim black-50 underline" target="_blank">Mercatus Center</a>.
 		</p>
+		<p class="black-40 f6 mb0">
+			Data and code hosted open-source on <a href="https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas"
+				class="link dim black-50 underline" target="_blank">GitHub</a>.
+		</p>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
Change adds a new paragraph with the CWA GH link at the bottom of the sidebar. Closes #116. 🫡 ![CleanShot 2024-04-24 at 15 31 26](https://github.com/CodeWithAloha/Hawaii-Zoning-Atlas/assets/20919083/9866dfa7-ce8d-4f35-aac3-4094b6ad7686)